### PR TITLE
fix a couple more tests

### DIFF
--- a/tests/transformers/tests/generation/test_framework_agnostic.py
+++ b/tests/transformers/tests/generation/test_framework_agnostic.py
@@ -49,7 +49,7 @@ class GenerationIntegrationTestsMixin:
         valid_model_kwargs = {"attention_mask": create_tensor_fn(np.zeros_like(input_ids))}
         model.generate(input_ids, **valid_model_kwargs)
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_custom_logits_processor(self):
         model_cls = self.framework_dependent_parameters["AutoModelForSeq2SeqLM"]
@@ -71,7 +71,7 @@ class GenerationIntegrationTestsMixin:
         bart_model.config.min_length = None
         bart_model.generate(input_ids, logits_processor=logits_processor)
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_max_new_tokens_encoder_decoder(self):
         model_cls = self.framework_dependent_parameters["AutoModelForSeq2SeqLM"]
@@ -229,7 +229,7 @@ class GenerationIntegrationTestsMixin:
         )
         self.assertTrue(np.allclose(transition_scores, expected_scores, atol=1e-3))
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_transition_scores_beam_search_encoder_decoder(self):
         model_cls = self.framework_dependent_parameters["AutoModelForSeq2SeqLM"]
@@ -266,7 +266,7 @@ class GenerationIntegrationTestsMixin:
 
         self.assertTrue(np.allclose(np.sum(transition_scores, axis=-1), outputs.sequences_scores, atol=1e-3))
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_transition_scores_beam_search_encoder_decoder_with_eos(self):
         model_cls = self.framework_dependent_parameters["AutoModelForSeq2SeqLM"]
@@ -302,7 +302,7 @@ class GenerationIntegrationTestsMixin:
 
         self.assertTrue(np.allclose(np.sum(transition_scores, axis=-1), outputs.sequences_scores, atol=1e-3))
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_transition_scores_beam_search_decoder_only(self):
         model_cls = self.framework_dependent_parameters["AutoModelForCausalLM"]
@@ -415,7 +415,7 @@ class GenerationIntegrationTestsMixin:
 
         self.assertTrue(np.allclose(np.sum(transition_scores, axis=-1), outputs.sequences_scores))
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_encoder_decoder_generate_attention_mask(self):
         model_cls = self.framework_dependent_parameters["AutoModelForSeq2SeqLM"]
@@ -518,7 +518,7 @@ class GenerationIntegrationTestsMixin:
         with self.assertRaises(ValueError):
             model.generate(input_ids=input_ids, inputs_embeds=input_ids)
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_generate_input_features_as_encoder_kwarg(self):
         model_cls = self.framework_dependent_parameters["AutoModelForSpeechSeq2Seq"]
@@ -561,7 +561,7 @@ class GenerationIntegrationTestsMixin:
         self.assertTrue(np.array_equal(output_sequences, output_sequences_kwargs))
         self.assertEqual(output_sequences.shape, (2, 5))
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_generate_encoder_outputs_attention_mask(self):
         model_cls = self.framework_dependent_parameters["AutoModelForSpeechSeq2Seq"]
@@ -588,8 +588,6 @@ class GenerationIntegrationTestsMixin:
 
         self.assertTrue(np.array_equal(output_sequences_no_mask, output_sequences_with_mask))
 
-    
-    @pytest.mark.xfail
     def test_eos_token_id_int_and_list_greedy_search(self):
         model_cls = self.framework_dependent_parameters["AutoModelForCausalLM"]
         return_tensors = self.framework_dependent_parameters["return_tensors"]
@@ -599,7 +597,6 @@ class GenerationIntegrationTestsMixin:
             "do_sample": False,
             "num_beams": 1,
         }
-        expectation = 13
 
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
@@ -609,6 +606,7 @@ class GenerationIntegrationTestsMixin:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)
 
+        expectation = model.config.max_length  # static shape should give max_length
         eos_token_id = 873
         generated_tokens = model.generate(**tokens, eos_token_id=eos_token_id, **generation_kwargs)
         self.assertTrue(expectation == len(generated_tokens[0]))
@@ -617,8 +615,6 @@ class GenerationIntegrationTestsMixin:
         generated_tokens = model.generate(**tokens, eos_token_id=eos_token_id, **generation_kwargs)
         self.assertTrue(expectation == len(generated_tokens[0]))
 
-    
-    @pytest.mark.xfail
     def test_eos_token_id_int_and_list_contrastive_search(self):
         model_cls = self.framework_dependent_parameters["AutoModelForCausalLM"]
         return_tensors = self.framework_dependent_parameters["return_tensors"]
@@ -630,7 +626,6 @@ class GenerationIntegrationTestsMixin:
             "penalty_alpha": 0.6,
             "top_k": 4,
         }
-        expectation = 17
 
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         text = """Hello, my dog is cute and"""
@@ -640,7 +635,9 @@ class GenerationIntegrationTestsMixin:
             model = model.to(torch_device)
             tokens = tokens.to(torch_device)
 
+        expectation = model.config.max_length  # static shape should give max_length
         eos_token_id = 225
+
         generated_tokens = model.generate(**tokens, eos_token_id=eos_token_id, **generation_kwargs)
         self.assertTrue(expectation == len(generated_tokens[0]))
 
@@ -648,7 +645,7 @@ class GenerationIntegrationTestsMixin:
         generated_tokens = model.generate(**tokens, eos_token_id=eos_token_id, **generation_kwargs)
         self.assertTrue(expectation == len(generated_tokens[0]))
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_eos_token_id_int_and_list_beam_search(self):
         model_cls = self.framework_dependent_parameters["AutoModelForCausalLM"]
@@ -675,7 +672,11 @@ class GenerationIntegrationTestsMixin:
         padded_correct_condition = expectation < len(generated_tokens[0]) and all(
             token == model.config.pad_token_id for token in generated_tokens[0][expectation:]
         )
-        self.assertTrue(unpadded_correct_condition or padded_correct_condition)
+        static_shape_condition = expectation < len(generated_tokens[0]) and all(
+            token == eos_token_id for token in generated_tokens[0][expectation:]
+        )
+        self.assertTrue(unpadded_correct_condition or padded_correct_condition or static_shape_condition)
+
 
         eos_token_id = [873, 198]
         generated_tokens = model.generate(**tokens, eos_token_id=eos_token_id, **generation_kwargs)
@@ -683,9 +684,12 @@ class GenerationIntegrationTestsMixin:
         padded_correct_condition = expectation < len(generated_tokens[0]) and all(
             token == model.config.pad_token_id for token in generated_tokens[0][expectation:]
         )
-        self.assertTrue(unpadded_correct_condition or padded_correct_condition)
+        static_shape_condition = expectation < len(generated_tokens[0]) and all(
+            token in eos_token_id for token in generated_tokens[0][expectation:]
+        )
+        self.assertTrue(unpadded_correct_condition or padded_correct_condition or static_shape_condition)
 
-    
+    # TODO [gustavo] Enable this test to Optimum-habana
     @pytest.mark.xfail
     def test_generate_vision2text_conditioning(self):
         model_cls = self.framework_dependent_parameters["AutoModelForVision2Seq"]

--- a/tests/transformers/tests/generation/test_utils.py
+++ b/tests/transformers/tests/generation/test_utils.py
@@ -65,8 +65,6 @@ if is_torch_available():
         BeamSampleEncoderDecoderOutput,
         BeamSearchDecoderOnlyOutput,
         BeamSearchEncoderDecoderOutput,
-        BeamSearchScorer,
-        ConstrainedBeamSearchScorer,
         DisjunctiveConstraint,
         GenerateBeamDecoderOnlyOutput,
         GenerateBeamEncoderDecoderOutput,


### PR DESCRIPTION
Here, we just add a couple of changes:
- On `optimum/habana/transformers/generation/utils.py` we avoid performing where when `self.config.eos_token_id` is null
- add note to tests on top of the `mark.xfail`
- fix a couple of tests
- removed unused variables